### PR TITLE
Add vigges.net, exchangetuts.com, fullstackuser.com as SO copycats

### DIFF
--- a/data/stackoverflow_copycats.txt
+++ b/data/stackoverflow_copycats.txt
@@ -261,3 +261,6 @@
 *://www.graef.io/*
 *://syntaxfix.com/*
 *://ourpython.com/*
+*://vigges.net/*
+*://exchangetuts.com/*
+*://fullstackuser.com/*


### PR DESCRIPTION
Original: https://stackoverflow.com/questions/46215614/property-does-not-exist-on-type-detailedhtmlprops-htmldivelement-with-react

Copycats:
* https://vigges.net/qa/?qa=806953/
* https://exchangetuts.com/property-does-not-exist-on-type-detailedhtmlprops-htmldivelement-with-react-16-1639588328847739
* https://fullstackuser.com/questions/219979/property-does-not-exist-on-type-detailedhtmlprops-htmldivelement-with-react